### PR TITLE
Create jekyll.yml

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,16 @@
+name: Jekyll site CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build the site in the jekyll/builder container
+      run: |
+        docker run \
+        -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
+        jekyll/builder:latest /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"


### PR DESCRIPTION
#!/bin/sh


# wipe out the symlinks
if [ -d /usr/local/git ]; then
  find /usr/local/git -type f  | sed 's|/usr/local/git|/usr/local|g' | while read f; do [ -h "$f" ] && sudo rm $f || true; done
  sudo rm -rf /usr/local/git
fi

echo "OK - running the installer. Come back and press a key when you're done."
open disk-image/git*.pkg 

read -n 1

for file in /usr/local/git/bin/git "/usr/local/git/share/git-gui/lib/Git Gui.app/Contents/Info.plist"; do
  printf "'$file'"
  if [ -f "$file" ]; then
    echo " - exists"
  else
    echo " DOES NOT EXIST!"
    for n in {1..20}; do
      echo "FAIL FAIL FAIL"
    done
    exit 1
  fi
done

echo "Testing..."

(cd stage/*-$GIT_VERSION; find usr) | while read f; do
  if ! [ -e "/$f" ]; then
    echo "/$f did not get installed!"
    exit 1
  fi
done

if (ls -alR /usr/local/git/* | awk '{print $3}' | grep `whoami`); then
  echo "Some user-owned files exist!"
  exit 1
fi
mahedi7up
I have XCode installed (and consequently its bundled git); how do I get my system to use this version instead?

Xcode installs its git to `/usr/bin/git`; recent versions of `OS X`
(Yosemite and later) ship with stubs in /usr/bin, which take
precedence over this git. To overcome, do the following:

    sudo mv /usr/bin/git /usr/bin/git-system
    sudo ln -sf /usr/local/git/bin/git /usr/bin/git

Note, you will need to restart your shell after so-doing, as most shells (bash) cache command location resolution from PATH.

## Which version should I download?

If you are running:

- `10.6` Snow Leopard: git-*-snow-leopard
- `10.7` Lion: git-*-snow-leopard
- `10.8` Mountain Lion: git-*-snow-leopard
- `10.9` Mavericks: git-*-mavericks
- `10.10` Yosemite: git-*-mavericks
- `10.11` Yosemite: git-*-mavericks

The Snow Leopard builds will work on Mavericks and later, but there are issues running `git gui`.

## It doesn't work. Help!

Scream where you can be heard. File an issue here: https://github.com/timcharper/git_osx_installer/issues

# Changes / Recent updates

## 2015-10-18

Builds have been updated to create symlinks in `/usr/local/bin` to run git. El Capitan no longer allows modifications to `/usr/bin`, and `/usr/local/bin` is preferred over `/usr/bin`, by default.

The installer installs the `uninstall.sh` script, which has also been updated to remove the new symlinks created.

The installer no longer uses `PackageMaker`. Instead, it uses `pkgbuild`, which is much simpler, and is the supported way of doing packages.

## 2014-12-21

Mavericks builds have been published to address issues running `git gui`. Going forward, `Snow Leopard` and `Mavericks` builds will be published.

Also, the Makefile has been fixed to enable 32-bit builds of the OS X keychain credential helper. Universal builds have returned, reducing one more decision the user has to make when determining the appropriate download version.

## 2014-12-20

32-bit builds for Snow Leopard (and later) are back. These were created on a 64-bit installation of Mac OS X Snow Leopard.

## 2014-12-19 - CVE-2014-9390 Fix, and improved build process.

### CVE-2014-9390 security fix

As [announced](http://article.gmane.org/gmane.linux.kernel/1853266) on the git mailing list, git for OS X

The following versions contain the fix:

- 2.2.1
- 2.1.4
- 2.0.5
- 1.9.5
- 1.8.5.6

### Support for older operating systems restored / apology

64-bit builds for Snow Leopard (and later) have been published. There was an issue with the build script in which the compilation Framework was not being properly specified, and this effectively caused it to be ignored. As a result, the builds were not working on 10.8.x and earlier. I apologize deeply for this error. Further compounding the issue was lack of feedback channels, and the negative reviews were not emailed to me. This was my fault as I did not set up adequate instructions for how to ask for help. I've updated the project home page with a link to the [GitHub issue tracker](https://github.com/timcharper/git_osx_installer/issues), and have done various cleanup to reduce clutter remaining since the transition from Google Code.

### Improved build process

The build process has been greatly improved; the cumbersome script has been replaced with a more declarative Makefile. A check has been added to assert that the 32-bit package actually contain 32-bit executables.
echo "Success!"

Copyright (c) 2012 Tim Harper and contributors.

Permission is hereby granted, free of charge, to any person obtaining
a copy of this software and associated documentation files (the
"Software"), to deal in the Software without restriction, including
without limitation the rights to use, copy, modify, merge, publish,
distribute, sublicense, and/or sell copies of the Software, and to
permit persons to whom the Software is furnished to do so, subject to
the following conditions:

The above copyright notice and this permission notice shall be
included in all copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
!/usr/bin/env ruby

install_prefix = ARGV[0]
puts install_prefix
git_binary = File.join(install_prefix, '/usr/local/git/bin/git')

[
  ['git'          , File.join(install_prefix, '/usr/local/git/bin')],
  ['../../bin/git', File.join(install_prefix, '/usr/local/git/libexec/git-core')]
].each do |link, path|
  Dir.glob(File.join(path, '*')).each do |file|
    next if file == git_binary
        puts "#{file} #{File.size(file)} == #{File.size(git_binary)}"
    next unless File.size(file) == File.size(git_binary)
    puts "Symlinking #{file}"
    puts `ln -sf #{link} #{file}`
    exit $?.exitstatus if $?.exitstatus != 0
  end
end

#!/bin/bash -e
if [ ! -r "/usr/local/git" ]; then
  echo "Git doesn't appear to be installed via this installer.  Aborting"
  exit 1
fi
echo "This will uninstall git by removing /usr/local/git/, and symlinks"
printf "Type 'yes' if you are sure you wish to continue: "
read response
if [ "$response" == "yes" ]; then
  # remove all of the symlinks we've created
  pkgutil --files com.git.pkg | grep bin | while read f; do
    if [ -L /usr/local/$f ]; then
      sudo rm /usr/local/$f
    fi
  done

  # forget receipts.
  pkgutil --packages | grep com.git.pkg | xargs -I {} sudo pkgutil --forget {}
  echo "Uninstalled"

  # The guts all go here.
  sudo rm -rf /usr/local/git/
else
  echo "Aborted"
  exit 1
fi

exit 0
Git OSX Installer
=================
=================

https://github.com/timcharper/git_osx_installer/


INSTALLATION
============

Step 1 - Install Package
------------------------
Double-click the package in this disk image to install. This installs
git to /usr/local/git, and places symlinks into /usr/local/bin and
/usr/share/man/.


Step 2 - Remove stubs (Yosemite and earlier)
--------------------------------------------
When you run `git`, you might see this message:

    'The "git" command requires the command line developer
    tools. Would you like to install the tools now?"

This is because OS X ships with stubs, and these stubs are taking
precedence over /usr/local/bin.

To resolve, run the following:

    sudo mv /usr/bin/git /usr/bin/git-system

This should not be a problem in OS X 10.11 (El Capitan), as
/usr/local/bin takes precedence over /usr/bin


UNINSTALLING
============

Run the uninstall script in /usr/local/git/uninstall.sh

NOTES ABOUT THIS BUILD
============

* Since Mac OS X does not ship with gettext, this build does not
  include gettext support. If popular demand requests (via the git
  issue tracker
  http://code.google.com/p/git-osx-installer/issues/list) the
  installer may bundle gettext in the future to provide localization
  support.

KNOWN ISSUES
============


Git GUI / gitk won't open - complain of missing Tcl / Tk Aqua libraries
-----------------------------------------------------------------------

If you don't already have Tcl/Tk Aqua installed on your computer (most
MacOS X installs have it), you will get this error message. To resolve
it, simply go to the website for Tcl / Tk Aqua and download the latest
version:

http://www.categorifiedcoder.info/tcltk/

If you have an older version of Tcl / Tk Aqua, you'll benefit from
upgrading.

More information:

http://code.google.com/p/git-osx-installer/issues/detail?id=41



Installer hangs during install (and I have iPhone developer tools installed)
----------------------------------------------------------------------------

The iPhone developer tools require some kind of gnarly system lock
that causes the MacOS X installer system to hang. Just quit the iPhone
SDK and try again.

More information:

http://code.google.com/p/git-osx-installer/issues/detail?id=35



"git-svn is missing"
--------------------
Mac OS X no longer ships with SVN, and this installer no longer ships
with git-svn support.

Complain about that here:

https://github.com/timcharper/git_osx_installer/issues

Handling of international characters in file is broken
------------------------------------------------------

If you would like some validation, read this: http://is.gd/5NAN9.
You're not alone.

This is not an issue with Git, not the installer. Apparently
subversion has it too.
/usr/local/git/share/man
mahedi7up
/usr/local/git/bin
Thu Nov 14 03:16:22 on console

The default interactive shell is now zsh.
To update your account to use zsh, please run `chsh -s /bin/zsh`.
For more details, please visit https://support.apple.com/kb/HT208050.
Mahedis-iMac:~ mahedi7up$
find-dir
find-file
latest-git-version
#!/bin/bash -e
if [ ! -r "/usr/local/git" ]; then
  echo "Git doesn't appear to be installed via this installer.  Aborting"
  exit 1
fi
echo "This will uninstall git by removing /usr/local/git/, and symlinks"
printf "Type 'yes' if you are sure you wish to continue: "
read response
if [ "$response" == "yes" ]; then
  # remove all of the symlinks we've created
  pkgutil --files com.git.pkg | grep bin | while read f; do
    if [ -L /usr/local/$f ]; then
      sudo rm /usr/local/$f
    fi
  done

  # forget receipts.
  pkgutil --packages | grep com.git.pkg | xargs -I {} sudo pkgutil --forget {}
  echo "Uninstalled"

  # The guts all go here.
  sudo rm -rf /usr/local/git/
else
  echo "Aborted"
  exit 1
fi

exit 0
gitconfig.default
gitconfig.osxkeychain
# Contributor Covenant Code of Conduct

## Our Pledge

In the interest of fostering an open and welcoming environment, we as
contributors and maintainers pledge to making participation in our project and
our community a harassment-free experience for everyone, regardless of age, body
size, disability, ethnicity, gender identity and expression, level of experience,
nationality, personal appearance, race, religion, or sexual identity and
orientation.

## Our Standards

Examples of behavior that contributes to creating a positive environment
include:

* Using welcoming and inclusive language
* Being respectful of differing viewpoints and experiences
* Gracefully accepting constructive criticism
* Focusing on what is best for the community
* Showing empathy towards other community members

Examples of unacceptable behavior by participants include:

* The use of sexualized language or imagery and unwelcome sexual attention or
advances
* Trolling, insulting/derogatory comments, and personal or political attacks
* Public or private harassment
* Publishing others' private information, such as a physical or electronic
  address, without explicit permission
* Other conduct which could reasonably be considered inappropriate in a
  professional setting
* Attempting to contact maintainers outside of GitHub.com without an explicit
  invitation to do so.

## Our Responsibilities

Project maintainers are responsible for clarifying the standards of acceptable
behavior and are expected to take appropriate and fair corrective action in
response to any instances of unacceptable behavior.

Project maintainers have the right and responsibility to remove, edit, or
reject comments, commits, code, wiki edits, issues, and other contributions
that are not aligned to this Code of Conduct, or to ban temporarily or
permanently any contributor for other behaviors that they deem inappropriate,
threatening, offensive, or harmful.

## Scope

This Code of Conduct applies both within project spaces and in public spaces
when an individual is representing the project or its community. Examples of
representing a project or community include using an official project e-mail
address, posting via an official social media account, or acting as an appointed
representative at an online or offline event. Representation of a project may be
further defined and clarified by project maintainers.

## Enforcement

Instances of abusive, harassing, or otherwise unacceptable behavior may be
reported by contacting the project team at opensource@github.com. All
complaints will be reviewed and investigated and will result in a response that
is deemed necessary and appropriate to the circumstances. The project team is
obligated to maintain confidentiality with regard to the reporter of an incident.
Further details of specific enforcement policies may be posted separately.

Project maintainers who do not follow or enforce the Code of Conduct in good
faith may face temporary or permanent repercussions as determined by other
members of the project's leadership.

## Attribution

This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
available at [http://contributor-covenant.org/version/1/4][version]

[homepage]: http://contributor-covenant.org
[version]: http://contributor-covenant.org/version/1/4/
# [GitHub Desktop](https://desktop.github.com)

[![Travis](https://img.shields.io/travis/desktop/desktop.svg?style=flat-square&label=Travis+CI)](https://travis-ci.org/desktop/desktop)
[![CircleCI](https://img.shields.io/circleci/project/github/desktop/desktop.svg?style=flat-square&label=CircleCI)](https://circleci.com/gh/desktop/desktop)
[![AppVeyor Build Status](https://img.shields.io/appveyor/ci/github-windows/desktop/development.svg?style=flat-square&label=AppVeyor&logo=appveyor)](https://ci.appveyor.com/project/github-windows/desktop/branch/development)
[![Azure DevOps Pipelines Build Status](https://dev.azure.com/github/Desktop/_apis/build/status/Continuous%20Integration)](https://dev.azure.com/github/Desktop/_build/latest?definitionId=3)
[![license](https://img.shields.io/github/license/desktop/desktop.svg?style=flat-square)](https://github.com/desktop/desktop/blob/development/LICENSE)
![90+% TypeScript](https://img.shields.io/github/languages/top/desktop/desktop.svg?style=flat-square&colorB=green)

GitHub Desktop is an open source [Electron](https://electron.atom.io)-based
GitHub app. It is written in [TypeScript](http://www.typescriptlang.org) and
uses [React](https://facebook.github.io/react/).

![GitHub Desktop screenshot - Windows](https://cloud.githubusercontent.com/assets/359239/26094502/a1f56d02-3a5d-11e7-8799-23c7ba5e5106.png)

## Where can I get it?

Download the official installer for your operating system:

 - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin)
 - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32)
 - [Windows machine-wide install](https://central.github.com/deployments/desktop/desktop/latest/win32?format=msi)

You can install this alongside your existing GitHub Desktop for Mac or GitHub
Desktop for Windows application.

**NOTE**: there is no current migration path to import your existing
repositories into the new application - you can drag-and-drop your repositories
from disk onto the application to get started.

### Beta Channel

Want to test out new features and get fixes before everyone else? Install the
beta channel to get access to early builds of Desktop:

 - [macOS](https://central.github.com/deployments/desktop/desktop/latest/darwin?env=beta)
 - [Windows](https://central.github.com/deployments/desktop/desktop/latest/win32?env=beta)

### Community Releases

There are several community-supported package managers that can be used to
install GitHub Desktop:
 - Windows users can install using [Chocolatey](https://chocolatey.org/) package manager:
      `c:\> choco install github-desktop`
 - macOS users can install using [Homebrew](https://brew.sh/) package manager:
      `$ brew cask install github`

Installers for various Linux distributions can be found on the
[`shiftkey/desktop`](https://github.com/shiftkey/desktop) fork.

Arch Linux users can install the latest version from the
[AUR](https://aur.archlinux.org/packages/github-desktop-bin/).

## Is GitHub Desktop right for me? What are the primary areas of focus?

[This document](https://github.com/desktop/desktop/blob/development/docs/process/what-is-desktop.md) describes the focus of GitHub Desktop and who the product is most useful for.

And to see what the team is working on currently and in the near future, check out the [GitHub Desktop roadmap](https://github.com/desktop/desktop/blob/development/docs/process/roadmap.md).

## I have a problem with GitHub Desktop

Note: The [GitHub Desktop Code of Conduct](https://github.com/desktop/desktop/blob/development/CODE_OF_CONDUCT.md) applies in all interactions relating to the GitHub Desktop project.

First, please search the [open issues](https://github.com/desktop/desktop/issues?q=is%3Aopen)
and [closed issues](https://github.com/desktop/desktop/issues?q=is%3Aclosed)
to see if your issue hasn't already been reported (it may also be fixed).

There is also a list of [known issues](https://github.com/desktop/desktop/blob/development/docs/known-issues.md)
that are being tracked against Desktop, and some of these issues have workarounds.

If you can't find an issue that matches what you're seeing, open a [new issue](https://github.com/desktop/desktop/issues/new/choose),
choose the right template and provide us with enough information to investigate
further.

## The issue I reported isn't fixed yet. What can I do?

If nobody has responded to your issue in a few days, you're welcome to respond to it with a friendly ping in the issue. Please do not respond more than a second time if nobody has responded. The GitHub Desktop maintainers are constrained in time and resources, and diagnosing individual configurations can be difficult and time consuming. While we'll try to at least get you pointed in the right direction, we can't guarantee we'll be able to dig too deeply into any one person's issue.

## How can I contribute to GitHub Desktop?

The [CONTRIBUTING.md](./.github/CONTRIBUTING.md) document will help you get setup and
familiar with the source. The [documentation](docs/) folder also contains more
resources relevant to the project.

If you're looking for something to work on, check out the [help wanted](https://github.com/desktop/desktop/issues?q=is%3Aissue+is%3Aopen+label%3A%22help%20wanted%22) label.

## More Resources

See [desktop.github.com](https://desktop.github.com) for more product-oriented
information about GitHub Desktop.

## License

**[MIT](LICENSE)**

The MIT license grant is not for GitHub's trademarks, which include the logo
designs. GitHub reserves all trademark and copyright rights in and to all
GitHub trademarks. GitHub's logos include, for instance, the stylized
Invertocat designs that include "logo" in the file title in the following
folder: [logos](app/static/logos).

GitHub® and its stylized versions and the Invertocat mark are GitHub's
Trademarks or registered Trademarks. When using GitHub's logos, be sure to
follow the GitHub [logo guidelines](https://github.com/logos).
opyright (c) GitHub, Inc.

Permission is hereby granted, free of charge, to any person obtaining a copy
of this software and associated documentation files (the "Software"), to deal
in the Software without restriction, including without limitation the rights
to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
copies of the Software, and to permit persons to whom the Software is
furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
SOFTWARE.
# Your GitHub Learning Lab Repository for Introducing GitHub

Welcome to **your** repository for your GitHub Learning Lab course. This repository will be used during the different activities that I will be guiding you through. See a word you don't understand? We've included an emoji 📖 next to some key terms. Click on it to see its definition.

Oh! I haven't introduced myself...

I'm the GitHub Learning Lab bot and I'm here to help guide you in your journey to learn and master the various topics covered in this course. I will be using Issue and Pull Request comments to communicate with you. In fact, I already added an issue for you to check out.

![issue tab](https://lab.github.com/public/images/issue_tab.png)

I'll meet you over there, can't wait to get started!

This course is using the :sparkles: open source project [reveal.js](https://github.com/hakimel/reveal.js/). In some cases we’ve made changes to the history so it would behave during class, so head to the original project repo to learn more about the cool people behind this project.
timezone:    Europe/Berlin
future:      false
# Set baseurl to the base path of the site eg "/mytalk"
baseurl:     "/github-slideshow"
# The allowed values are 'rouge', 'pygments' or null.
highlighter: rouge
# markdown - Valid options are [ maruku | rdiscount | kramdown | redcarpet ]
markdown:    kramdown
lsi:         false
permalink:   "/:title"

kramdown:
  ## for german: "sbquo,lsquo,bdquo,ldquo"
  smart_quotes: lsquo,rsquo,ldquo,rdquo

plugins:
  - jemoji

## personalize your slide show
title:       github-slideshow
author:      GitHubTeacher
description: A fun activity for learning Git and GitHub.

sass:
  style:     :compressed

## solarized variant (dark/light)
solarized:
  theme:     dark

slideNumber:
  # Slide number formatting can be configured using these variables:
  #  "h.v":  horizontal . vertical slide number (default)
  #  "h/v":  horizontal / vertical slide number
  #    "c":  flattened slide number
  #  "c/t":  flattened slide number / total slides
  # "none":  dont't show slide numbers
  format:    "c/t"

## Reveal.initialize
## At the end of your page Jekyll initializes reveal by running the following code. Note that all config values are optional and will default as specified below.
## Note that the new default vertical centering option will break compatibility with slides that were using transitions with backgrounds ("cube" and "page"). To restore the previous behavior, set "center" to "false".
reveal:
  ## Display controls in the bottom right corner
  controls: false
  ## Display a presentation progress bar
  progress: true
  ## Display the page number of the current slide
  #slideNumber: false
  ## Push each slide change to the browser history
  history: true
  ## Enable keyboard shortcuts for navigation
  keyboard: true
  ## Enable the slide overview mode
  overview: true
  ## Vertical centering of slides
  center: true
  ## Enables touch navigation on devices with touch input
  touch: true
  ## Loop the presentation
  loop: false
  ## Change the presentation direction to be RTL
  #rtl: false
  ## Turns fragments on and off globally
  fragments: true
  ## Flags if the presentation is running in an embedded mode
  ## i.e. contained within a limited portion of the screen
  #embedded: false
  ## Number of milliseconds between automatically proceeding to the
  ## next slide, disabled when set to 0, this value can be overwritten
  ## by using a data-autoslide attribute on your slides
  #autoSlide: 0
  ## Stop auto-sliding after user input
  #autoSlideStoppable: true
  ## Enable slide navigation via mouse wheel
  #mouseWheel: false
  ## Hides the address bar on mobile devices
  #hideAddressBar: true
  ## Opens links in an iframe preview overlay
  #previewLinks: false
  ## Transition style (default/cube/page/concave/zoom/linear/fade/none)
  transition: linear
  ## Transition speed (default/fast/slow)
  #transitionSpeed: default
  ## Transition style for full page slide backgrounds (default/none/slide/concave/convex/zoom)
  backgroundTransition: slide
  ## Number of slides away from the current that are visible
  #viewDistance: 3
  ## Parallax background image (e.g. "'https://s3.amazonaws.com/hakim-static/reveal-js/reveal-parallax-1.jpg'")
  #parallaxBackgroundImage: ''
  ## Parallax background size (CSS syntax, e.g. "2100px 900px")
  #parallaxBackgroundSize: ''
  ## The "normal" size of the presentation, aspect ratio will be preserved
  ## when the presentation is scaled to fit different resolutions. Can be
  ## specified using percentage units.
  width: 1000
  height: 920
  ## Factor of the display size that should remain empty around the content
  margin: 0.1
  ## Bounds for smallest/largest possible scale to apply to content
  minScale: 0.2
  maxScale: 1.5

exclude: [
  "Gemfile",
  "Gemfile.lock",
  "vendor",
  "reveal.js/test",
  "reveal.js/index.html",
  "reveal.js/README.md",
  "reveal.js/bower.json",
  "reveal.js/Gruntfile.js",
  "reveal.js/CONTRIBUTING.md",
  "reveal.js/LICENSE",
  "reveal.js/package.json"
]
machine:
  ruby:
    version: 2.3.1
dependencies:
  pre:
    - script/setup
test:
  override:
    - script/cibuild
Git OSX Installer
=================
=================

https://github.com/timcharper/git_osx_installer/


INSTALLATION
============

Step 1 - Install Package
------------------------
Double-click the package in this disk image to install. This installs
git to /usr/local/git, and places symlinks into /usr/local/bin and
/usr/share/man/.


Step 2 - Remove stubs (Yosemite and earlier)
--------------------------------------------
When you run `git`, you might see this message:

    'The "git" command requires the command line developer
    tools. Would you like to install the tools now?"

This is because OS X ships with stubs, and these stubs are taking
precedence over /usr/local/bin.

To resolve, run the following:

    sudo mv /usr/bin/git /usr/bin/git-system

This should not be a problem in OS X 10.11 (El Capitan), as
/usr/local/bin takes precedence over /usr/bin


UNINSTALLING
============

Run the uninstall script in /usr/local/git/uninstall.sh

NOTES ABOUT THIS BUILD
============

* Since Mac OS X does not ship with gettext, this build does not
  include gettext support. If popular demand requests (via the git
  issue tracker
  http://code.google.com/p/git-osx-installer/issues/list) the
  installer may bundle gettext in the future to provide localization
  support.

KNOWN ISSUES
============


Git GUI / gitk won't open - complain of missing Tcl / Tk Aqua libraries
-----------------------------------------------------------------------

If you don't already have Tcl/Tk Aqua installed on your computer (most
MacOS X installs have it), you will get this error message. To resolve
it, simply go to the website for Tcl / Tk Aqua and download the latest
version:

http://www.categorifiedcoder.info/tcltk/

If you have an older version of Tcl / Tk Aqua, you'll benefit from
upgrading.

More information:

http://code.google.com/p/git-osx-installer/issues/detail?id=41



Installer hangs during install (and I have iPhone developer tools installed)
----------------------------------------------------------------------------

The iPhone developer tools require some kind of gnarly system lock
that causes the MacOS X installer system to hang. Just quit the iPhone
SDK and try again.

More information:

http://code.google.com/p/git-osx-installer/issues/detail?id=35



"git-svn is missing"
--------------------
Mac OS X no longer ships with SVN, and this installer no longer ships
with git-svn support.

Complain about that here:

https://github.com/timcharper/git_osx_installer/issues

Handling of international characters in file is broken
------------------------------------------------------

If you would like some validation, read this: http://is.gd/5NAN9.
You're not alone.

This is not an issue with Git, not the installer. Apparently
subversion has it too.
